### PR TITLE
support test.Client.logout()

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -274,6 +274,18 @@ class ClientTest(TestCase):
         assert client.login(username='bouke', password='secret')
         self.assertEqual(client.session['foo'], 'bar')
 
+    def test_login_logout(self):
+        client = Client()
+        User.objects.create_user('bouke', '', 'secret')
+        assert client.login(username='bouke', password='secret')
+        assert settings.SESSION_COOKIE_NAME in client.cookies
+
+        client.logout()
+        assert settings.SESSION_COOKIE_NAME not in client.cookies
+
+        # should not raise
+        client.logout()
+
     @override_settings(INSTALLED_APPS=())
     def test_no_session(self):
         self.assertIsNone(Client().session)

--- a/user_sessions/utils/tests.py
+++ b/user_sessions/utils/tests.py
@@ -52,6 +52,18 @@ class Client(BaseClient):
         else:
             return False
 
+    def logout(self):
+        """
+        Removes the authenticated user's cookies and session object.
+
+        Causes the authenticated user to be logged out.
+        """
+        session_cookie = self.cookies.get(settings.SESSION_COOKIE_NAME)
+        if session_cookie:
+            if self.session:
+                self.session.delete(session_cookie)
+            del self.cookies[settings.SESSION_COOKIE_NAME]
+
     def _session(self):
         """
         Obtains the current session variables.


### PR DESCRIPTION
logout() support for the test client so it can be used in Webtests. Resolves issue #29 