### PR TITLE
fallback for ip optional

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -14,9 +14,9 @@ class SessionMiddleware(object):
         engine = import_module(settings.SESSION_ENGINE)
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
         ip = request.META.get('REMOTE_ADDR', None)
-        if not ip:
+        if not ip and hasattr(settings, 'USER_SESSIONS_IP_FALLBACK'):
             # check for fallback e.g. behind a proxy
-            x_fallback = settings.get('USER_SESSIONS_IP_FALLBACK', None)
+            x_fallback = settings.USER_SESSIONS_IP_FALLBACK
             if not x_fallback:
                 raise AttributeError('No IP for REMOTE_ADDR and no fallback set')
             ip = request.META.get(x_fallback, None)

--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -14,7 +14,7 @@ class SessionMiddleware(object):
         engine = import_module(settings.SESSION_ENGINE)
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
         request.session = engine.SessionStore(
-            ip=request.META.get('REMOTE_ADDR', request.META.get('HTTP_X_FORWARDED_FOR', '')),
+            ip=request.META.get('REMOTE_ADDR') or request.META.get('HTTP_X_FORWARDED_FOR', ''),
             user_agent=request.META.get('HTTP_USER_AGENT', ''),
             session_key=session_key
         )

--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -14,7 +14,7 @@ class SessionMiddleware(object):
         engine = import_module(settings.SESSION_ENGINE)
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
         request.session = engine.SessionStore(
-            ip=request.META.get('REMOTE_ADDR', ''),
+            ip=request.META.get('REMOTE_ADDR', request.META.get('HTTP_X_FORWARDED_FOR', '')),
             user_agent=request.META.get('HTTP_USER_AGENT', ''),
             session_key=session_key
         )


### PR DESCRIPTION
With this commit it would be optional to provide a fallback for reliable IP information.
otherwise we would get an integrity error so with the attribute error the user knows whats going wrong