### PR TITLE
Django 1.8 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ contains the package `django-two-factor-auth`_, but that application is not a
 dependency for this package. Also have a look at the bundled example templates
 and views to see how you can integrate the application into your project.
 
-Compatible with Django 1.4, 1.5, 1.6 and 1.7 on Python 2.6, 2.7, 3.2, 3.3 and
+Compatible with Django 1.4, 1.5, 1.6, 1.7 and 1.8 on Python 2.6, 2.7, 3.2, 3.3 and
 3.4. Documentation is available at `readthedocs.org`_.
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,10 @@ envlist =
     py32-django17,
     py33-django17,
     py34-django17,
+    py27-django18,
+    py32-django18,
+    py33-django18,
+    py34-django18,
     flake8
 
 [testenv]
@@ -117,6 +121,30 @@ deps =
 basepython = python3.4
 deps =
     Django>=1.7,<1.8
+    {[testenv]deps}
+
+[testenv:py27-django18]
+basepython = python2.7
+deps =
+    Django>=1.8,<1.9
+    {[testenv]deps}
+
+[testenv:py32-django18]
+basepython = python3.2
+deps =
+    Django>=1.8,<1.9
+    {[testenv]deps}
+
+[testenv:py33-django18]
+basepython = python3.3
+deps =
+    Django>=1.8,<1.9
+    {[testenv]deps}
+
+[testenv:py34-django18]
+basepython = python3.4
+deps =
+    Django>=1.8,<1.9
     {[testenv]deps}
 
 [testenv:flake8]


### PR DESCRIPTION
Everything appears to be working properly so far so this only adds the configuration for tox but does not fix anything specific.

It'd actually be awesome if you guys could release a new version with 1.7 and 1.8 support if there are no known blockers.