### PR TITLE
Update middleware.py to remove warning.

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -3,8 +3,10 @@ import time
 from django.conf import settings
 from django.utils.cache import patch_vary_headers
 from django.utils.http import cookie_date
-from django.utils.importlib import import_module
-
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 class SessionMiddleware(object):
     """


### PR DESCRIPTION
Suppress the `RemovedInDjango19Warning`