### PR TITLE
Fix Django 1.9 and Python 3.2+ deprecation warnings

### DIFF
--- a/example/urls.py
+++ b/example/urls.py
@@ -10,7 +10,10 @@ urlpatterns = patterns(
     '',
     url(
         regex=r'^$',
-        view=RedirectView.as_view(url=reverse_lazy('user_sessions:session_list')),
+        view=RedirectView.as_view(
+            url=reverse_lazy('user_sessions:session_list'),
+            permanent=True,
+        ),
         name='home',
     ),
     url(r'', include('user_sessions.urls', 'user_sessions')),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -15,6 +15,7 @@ from django.core.urlresolvers import reverse
 from django.db import IntegrityError
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils import six
 from django.utils.timezone import now
 
 from user_sessions.backends.db import SessionStore
@@ -212,7 +213,8 @@ class SessionStoreTest(TestCase):
 
     def test_integrity(self):
         self.store.user_agent = None
-        with self.assertRaisesRegexp(
+        with six.assertRaisesRegex(
+                self,
                 IntegrityError,
                 '(user_sessions_session.user_agent may not be NULL|'
                 'NOT NULL constraint failed: user_sessions_session.user_agent)'

--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -3,7 +3,11 @@ import time
 from django.conf import settings
 from django.utils.cache import patch_vary_headers
 from django.utils.http import cookie_date
-from django.utils.importlib import import_module
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 
 class SessionMiddleware(object):


### PR DESCRIPTION
This fixes the 2 warnings, with Django 1.8 (which will become errors in 1.9) and 1 warning with Python 3.2+
```
(env)alex@martha:~/src/django-user-sessions/example$ ./manage.py check
...
/home/alex/src/django-user-sessions/user_sessions/middleware.py:6: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
  from django.utils.importlib import import_module

/home/alex/src/django-user-sessions/example/urls.py:13: RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
  view=RedirectView.as_view(url=reverse_lazy('user_sessions:session_list')),
```