### PR TITLE
Tox: Fix TemplateDoesNotExist with Django 1.4 environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,12 +29,16 @@ whitelist_externals = make
 
 [testenv:py26-django14]
 basepython = python2.6
+install_command = pip install --no-binary=Django {opts} {packages}
+recreate=True
 deps =
     Django>=1.4,<1.5
     {[testenv]deps}
 
 [testenv:py27-django14]
 basepython = python2.7
+install_command = pip install --no-binary=Django {opts} {packages}
+recreate=True
 deps =
     Django>=1.4,<1.5
     {[testenv]deps}


### PR DESCRIPTION
Recent versions of pip and virtualenv default to installing packages as wheels. This fails for Django 1.4, the templates are installed to the root of the virtualenv, rather than `.../site-packages/django/...`. When the user_session unit tests are run no templates can be found.

This commit forces pip to install Django 1.4 from it's source package.

`recreate=True` makes sure any existing, wheel based, environments are deleted. Once that's done, these lines could be removed.