### PR TITLE
Remove usused future templatetag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ contains the package `django-two-factor-auth`_, but that application is not a
 dependency for this package. Also have a look at the bundled example templates
 and views to see how you can integrate the application into your project.
 
-Compatible with Django 1.8 and 1.9 on Python 2.7, 3.2, 3.3, 3.4 and 3.5.
+Compatible with Django 1.8, 1.9 and 1.10 on Python 2.7, 3.2, 3.3, 3.4 and 3.5.
 Documentation is available at `readthedocs.org`_.
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 minversion = 1.8
 envlist =
     py{27,32,33,34,35}-django18,
-    py{27,34,35}-django19,
+    py{27,34,35}-{django19,django110},
     flake8
 
 [testenv]
@@ -11,6 +11,7 @@ commands = make test
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
     flake8: flake8
 whitelist_externals = make
 

--- a/user_sessions/templates/user_sessions/_base.html
+++ b/user_sessions/templates/user_sessions/_base.html
@@ -1,4 +1,3 @@
-{% load future %}
 <!DOCTYPE html>
 <html>
 <head>

--- a/user_sessions/templates/user_sessions/session_list.html
+++ b/user_sessions/templates/user_sessions/session_list.html
@@ -1,5 +1,5 @@
 {% extends "user_sessions/_base.html" %}
-{% load user_sessions i18n future %}
+{% load user_sessions i18n %}
 
 {% block content %}
   <h1>{% trans "Active Sessions" %}</h1>


### PR DESCRIPTION
All future tamplatetags defined in Django-1.8 already issued deprecation
warnings and in django-1.10 the future templatetag was removed.

This minor changes should allow use with django-1.10 without replacing the default templates.

unrelated but I'm curious, any reason you left out *.pyc and __pycache__ files/directories from the .gitignore?