### PR TITLE
Remove session_key from admin by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-user-sessions',
-    version='1.3.2',
+    version='1.3.1',
     description='Django sessions with a foreign key to the user',
     long_description=open('README.rst').read(),
     author='Bouke Haarsma',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-user-sessions',
-    version='1.3.1',
+    version='1.3.2',
     description='Django sessions with a foreign key to the user',
     long_description=open('README.rst').read(),
     author='Bouke Haarsma',

--- a/user_sessions/admin.py
+++ b/user_sessions/admin.py
@@ -2,6 +2,7 @@ import django
 from django.contrib import admin
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 
 try:
     from django.contrib.auth import get_user_model
@@ -52,7 +53,9 @@ class SessionAdmin(admin.ModelAdmin):
     search_fields = ()
     list_filter = ExpiredFilter, OwnerFilter
     raw_id_fields = 'user',
-    exclude = 'session_key',
+
+    if getattr(settings, 'USER_SESSIONS_ADMIN_EXCLUDE_SESSION_KEY',True):
+        exclude = 'session_key',
 
     def __init__(self, *args, **kwargs):
         super(SessionAdmin, self).__init__(*args, **kwargs)

--- a/user_sessions/admin.py
+++ b/user_sessions/admin.py
@@ -2,7 +2,6 @@ import django
 from django.contrib import admin
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
-from django.conf import settings
 
 try:
     from django.contrib.auth import get_user_model
@@ -53,9 +52,7 @@ class SessionAdmin(admin.ModelAdmin):
     search_fields = ()
     list_filter = ExpiredFilter, OwnerFilter
     raw_id_fields = 'user',
-
-    if getattr(settings, 'USER_SESSIONS_ADMIN_EXCLUDE_SESSION_KEY',True):
-        exclude = 'session_key',
+    exclude = 'session_key',
 
     def __init__(self, *args, **kwargs):
         super(SessionAdmin, self).__init__(*args, **kwargs)

--- a/user_sessions/admin.py
+++ b/user_sessions/admin.py
@@ -52,6 +52,7 @@ class SessionAdmin(admin.ModelAdmin):
     search_fields = ()
     list_filter = ExpiredFilter, OwnerFilter
     raw_id_fields = 'user',
+    exclude = 'session_key',
 
     def __init__(self, *args, **kwargs):
         super(SessionAdmin, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Exposing the session key via the admin interface could be considered unnecessary and
just makes it easier to impersonate a user which is, arguably, a
security risk.

The following PR makes this optional. I'd appreciate your opinion.

Thanks!
Callan Bryant