### PR TITLE
Update docs to explain IP issues when django runs behind a proxy

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,3 +21,16 @@ documentation on `installing GeoIP`_.
 
 .. _installing GeoIP:
    https://docs.djangoproject.com/en/1.6/ref/contrib/gis/geoip/
+
+IP Data Accuracy
+----------------
+If you're running Django behind a proxy like nginx, you will have to set 
+the `REMOTE_ADDR` META header manually using a middleware, to stop it from 
+always returning the ip of the proxy (e.g. 127.0.0.1 in many cases).
+
+An example middleware to fix this issue is https://github.com/allo-/django-xforwardedfor-middleware
+Which simply does this for each request:
+
+``request.META['REMOTE_ADDR'] = request.META['HTTP_X_FORWARDED_FOR'].split(',')[0].strip()``
+
+Your particular configuration may vary, X-Forwarded-For is not always accurate in some cases.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,8 +22,8 @@ documentation on `installing GeoIP`_.
 .. _installing GeoIP:
    https://docs.djangoproject.com/en/1.6/ref/contrib/gis/geoip/
 
-IP Data Accuracy
-----------------
+IP when behind a proxy
+----------------------
 If you're running Django behind a proxy like nginx, you will have to set 
 the `REMOTE_ADDR` META header manually using a middleware, to stop it from 
 always returning the ip of the proxy (e.g. 127.0.0.1 in many cases).
@@ -33,4 +33,6 @@ Which simply does this for each request:
 
 ``request.META['REMOTE_ADDR'] = request.META['HTTP_X_FORWARDED_FOR'].split(',')[0].strip()``
 
-Your particular configuration may vary, X-Forwarded-For is not always accurate in some cases.
+Your particular configuration may vary, `X-Forwarded-For` must be set by
+a proxy that you have control over, otherwise it might be spoofed by the
+client.


### PR DESCRIPTION
I've noticed this is a common issue with this repo, and many [PRs and issues](https://github.com/Bouke/django-user-sessions/pull/21) have been opened to try and resolve it.

Rather than deal with this coming up repeatedly, lets add a section to the docs explaining the common pitfalls associated with `X-Forwarded-For`.

Feel free to edit or suggest changes to this wording, this is a first draft.

It might also be prudent to mention the most common nginx config change needed to get this working:
```nginx
proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
```