### PR TITLE
Fix super() usage in SessionDeleteView

### DIFF
--- a/user_sessions/views.py
+++ b/user_sessions/views.py
@@ -50,7 +50,7 @@ class SessionDeleteView(LoginRequiredMixin, SessionMixin, DeleteView):
             next_page = getattr(settings, 'LOGOUT_REDIRECT_URL',
                                 getattr(settings, 'LOGOUT_URL', '/'))
             return redirect(resolve_url(next_page))
-        super().delete(request, *args, **kwargs)
+        return super(SessionDeleteView, self).delete(request, *args, **kwargs)
 
     def get_success_url(self):
         return str(reverse_lazy('user_sessions:session_list'))


### PR DESCRIPTION
The existing call to `super()` fails with a `TypeError: super() takes at least 1 argument (0 given)`. This fixes session deletion.

Additionally, the existing call doesn't return any value from `super` and returning `None` instead of a valid response object also raises an error.