### PR TITLE
Fix typo in template - use correct field

### DIFF
--- a/user_sessions/templates/user_sessions/session_list.html
+++ b/user_sessions/templates/user_sessions/session_list.html
@@ -19,7 +19,7 @@
     {% for object in object_list %}
       <tr {% if object.session_key == session_key %}class="active"{% endif %}>
         <td>{{ object.ip|location|default_if_none:unknown|safe }} <small>({{ object.ip }})</small></td>
-        <td>{{ object.user_agents|device|default_if_none:unknown_on_unknown|safe }}</td>
+        <td>{{ object.user_agent|device|default_if_none:unknown_on_unknown|safe }}</td>
         <td>
           {% if object.session_key == session_key %}
             {% blocktrans with time=object.last_activity|timesince %}{{ time }} ago (this session){% endblocktrans %}


### PR DESCRIPTION
Using the nonexistent field `user_agents` ends up displaying the default `unknown on unknown` for the user agent. This fixes the issue so that the correct UA value is displayed.