### PR TITLE
Added created field to Session model

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -201,6 +201,8 @@ class SessionStoreTest(TestCase):
         self.assertEqual(session.user_agent, 'Python/2.7')
         self.assertEqual(session.ip, '127.0.0.1')
         self.assertEqual(session.user_id, 1)
+        self.assertAlmostEqual(now(), session.created,
+                               delta=timedelta(seconds=5))
         self.assertAlmostEqual(now(), session.last_activity,
                                delta=timedelta(seconds=5))
 

--- a/user_sessions/admin.py
+++ b/user_sessions/admin.py
@@ -53,6 +53,7 @@ class SessionAdmin(admin.ModelAdmin):
     list_filter = ExpiredFilter, OwnerFilter
     raw_id_fields = 'user',
     exclude = 'session_key',
+    readonly_fields = 'created', 'last_activity',
 
     def __init__(self, *args, **kwargs):
         super(SessionAdmin, self).__init__(*args, **kwargs)

--- a/user_sessions/migrations/0004_session_created.py
+++ b/user_sessions/migrations/0004_session_created.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import datetime
+
+def set_created(apps, schema_editor):
+    Session = apps.get_model('user_sessions', 'Session')
+
+    for obj in Session.objects.all():
+        obj.created = obj.last_activity
+        obj.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('user_sessions', '0003_auto_20161205_1516'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='session',
+            name='created',
+            field=models.DateTimeField(default=datetime.datetime(2017, 4, 18, 12, 11, 0, 286186), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.RunPython(set_created),
+    ]

--- a/user_sessions/models.py
+++ b/user_sessions/models.py
@@ -52,7 +52,7 @@ class Session(models.Model):
     user_agent = models.CharField(null=True, blank=True, max_length=200)
     last_activity = models.DateTimeField(auto_now=True)
     ip = models.GenericIPAddressField(null=True, blank=True, verbose_name='IP')
-
+    created = models.DateTimeField(auto_now_add=True)
 
 # At bottom to avoid circular import
 from .backends.db import SessionStore  # noqa: E402


### PR DESCRIPTION
In response to Issue #66 I added the field myself and created this PR. Shouldn't negatively impact anything, and I made the migration set the `created` to be equal to the value of `last_activity` rather than being ahead of it for backward compatibility.