### PR TITLE
updated middleware.py to make it proxy proof

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -16,15 +16,24 @@ except ImportError:
         pass
 
 
+def get_ip(request):
+    if request.META.get('HTTP_X_FORWARDED_FOR') is None:
+        ip_address = request.META.get('REMOTE_ADDR')
+    else:
+        ip_address = request.META.get('HTTP_X_FORWARDED_FOR')
+    return ip_address
+
+
 class SessionMiddleware(MiddlewareMixin):
     """
     Middleware that provides ip and user_agent to the session store.
     """
+
     def process_request(self, request):
         engine = import_module(settings.SESSION_ENGINE)
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
         request.session = engine.SessionStore(
-            ip=request.META.get('REMOTE_ADDR', ''),
+            ip=get_ip(request),
             user_agent=request.META.get('HTTP_USER_AGENT', ''),
             session_key=session_key
         )


### PR DESCRIPTION
The middleware is now proxy proof. IP addresses will be displayed correctly.
Instead of the Proxy servers's IP addresses the X_FORWARDED_FOR ip_address will now be displayed.

CloudFlare proof.