### PR TITLE
Adds supporte for X-FORWARED_FOR

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -24,7 +24,7 @@ class SessionMiddleware(MiddlewareMixin):
         engine = import_module(settings.SESSION_ENGINE)
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
         request.session = engine.SessionStore(
-            ip=request.META.get('REMOTE_ADDR', ''),
+            ip=request.META.get('HTTP_X_FORWARDED_FOR', '') or request.META.get('REMOTE_ADDR', ''),
             user_agent=request.META.get('HTTP_USER_AGENT', ''),
             session_key=session_key
         )


### PR DESCRIPTION
## Description
Provides support for correctly identifying client ip address when the application server is behind a reverse proxy or load balancer.

## Motivation and Context
When using Django behind a Load Balancer or Reverse proxy (NGINX and Apache), the `REMOTE_ADDR` holds the the reverse proxy server IP address, not the clients IP address. The [de-facto standard](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) is to set `X-FORWARDED-FOR` in the header with the clients IP Address. This PR verifies If there is a `X-FORWARDED-FOR` header variable set and use it instead of the `REMOTE_ADDR`.


## How Has This Been Tested?
Manually tested (automated tests are not possible), using NGINX as a reverse proxy:

    location / {
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header Host $http_host;
        proxy_pass  http://my-app-server:8080;
    }

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
