### PR TITLE
fix bug: if regex.search(value):  TypeError: expected string or bytes…

### DIFF
--- a/user_sessions/templatetags/user_sessions.py
+++ b/user_sessions/templatetags/user_sessions.py
@@ -50,6 +50,9 @@ def device(value):
     * None
     """
 
+    if not value:
+        return None
+
     browser = None
     for regex, name in BROWSERS:
         if regex.search(value):


### PR DESCRIPTION
## Fix the following exception information.
```
"/Users/gavinsun/Research/Django/19.beautiful_app/django_app/user_sessions/templatetags/user_sessions.py", line 58, in device
    if regex.search(value):
TypeError: expected string or bytes-like object
[05/Jul/2018 15:52:06] "GET /account/sessions/ HTTP/1.1" 500 191771
```
## Description
In user_sessions/templatetags/user_sessions.py,line 58，when value is None, python throws an exception.  I added the following code in front to solve this problem.
```python
    if not value:
        return None
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
