### PR TITLE
fix deprecation warning. replace cookie_date with http_date.

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -2,7 +2,7 @@ import time
 
 from django.conf import settings
 from django.utils.cache import patch_vary_headers
-from django.utils.http import cookie_date
+from django.utils.http import http_date
 
 try:
     from importlib import import_module
@@ -49,7 +49,7 @@ class SessionMiddleware(MiddlewareMixin):
                 else:
                     max_age = request.session.get_expiry_age()
                     expires_time = time.time() + max_age
-                    expires = cookie_date(expires_time)
+                    expires = http_date(expires_time)
                 # Save the session data and refresh the client cookie.
                 # Skip session save for 500 responses, refs #3881.
                 if response.status_code != 500:


### PR DESCRIPTION
This change removes the use of `cookie_date`, which is deprecated as of Django2.1 and will be removed in 3.0. `http_date` should be used instead.

https://docs.djangoproject.com/en/2.1/ref/utils/#django.utils.http.cookie_date