### PR TITLE
Detect Edge browser in User Agent, fix #95

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -402,6 +402,19 @@ class DeviceTemplateFilterTest(TestCase):
                    'KHTML, like Gecko) Chrome/30.0.1599.101 Safari/537.36')
         )
 
+    def test_edge(self):
+        self.assertEquals(
+            'Edge on Windows 10',
+            device('Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, '
+                   'like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136')
+        )
+        self.assertEquals(
+            'Edge on Windows Mobile',
+            device('Mozilla/5.0 (Windows Mobile 10; Android 8.0.0; Microsoft; Lumia '
+                   '950XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 '
+                   'Mobile Safari/537.36 Edge/40.15254.369')
+        )
+
     def test_firefox_only(self):
         self.assertEqual("Firefox", device("Not a legit OS Firefox/51.0"))
 

--- a/user_sessions/templatetags/user_sessions.py
+++ b/user_sessions/templatetags/user_sessions.py
@@ -8,6 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 register = template.Library()
 
 BROWSERS = (
+    (re.compile('Edge'), _('Edge')),
     (re.compile('Chrome'), _('Chrome')),
     (re.compile('Safari'), _('Safari')),
     (re.compile('Firefox'), _('Firefox')),
@@ -15,6 +16,7 @@ BROWSERS = (
     (re.compile('IE'), _('Internet Explorer')),
 )
 DEVICES = (
+    (re.compile('Windows Mobile'), _('Windows Mobile')),
     (re.compile('Android'), _('Android')),
     (re.compile('Linux'), _('Linux')),
     (re.compile('iPhone'), _('iPhone')),


### PR DESCRIPTION
## Expected Behavior
When a session is used by Microsoft Edge browser it should be displayed as _Edge_ and not _Chrome_ in the list of sessions. 

## Current Behavior
Currently the browser is detected as 'Chrome'.

## Possible Solution
An example User Agent string is `Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136` . Yes, it's a mess.

User Agent to Browser name resolution is handled in https://github.com/Bouke/django-user-sessions/blob/master/user_sessions/templatetags/user_sessions.py . Edge should be detected first in the list of browsers regexes. 

An alternative option is to let an external library like https://pypi.org/project/httpagentparser handle browser detection. This would save ~60 lines of program code and ~120 lines of test code and make this project simpler, but I'm not sure if the maintainer would like to introduce an external dependency (so far, there are no external dependencies in this project).

Fixes #95 