### PR TITLE
Django 3 support

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -2,8 +2,9 @@ import time
 
 from django.conf import settings
 from django.utils.cache import patch_vary_headers
-from django.utils.http import cookie_date
 
+from django.utils.http import http_date
+    
 try:
     from importlib import import_module
 except ImportError:
@@ -49,7 +50,7 @@ class SessionMiddleware(MiddlewareMixin):
                 else:
                     max_age = request.session.get_expiry_age()
                     expires_time = time.time() + max_age
-                    expires = cookie_date(expires_time)
+                    expires = http_date(expires_time)
                 # Save the session data and refresh the client cookie.
                 # Skip session save for 500 responses, refs #3881.
                 if response.status_code != 500:


### PR DESCRIPTION
cookie_date has disappeared in favor of http_date

<!--- Provide a general summary of your changes in the Title above -->

## Description
I had a look auth the newer session middleware in Django 3.0.1 and it seems cookie_date was replaced by http_date

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Django 3 support
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
very light testing, I have to say...
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
Not sure if it breaks compatibility with a older supported django release.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
