### PR TITLE
Changed cookie_date (deprecated since Django 2.2) to http_date

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -2,7 +2,7 @@ import time
 
 from django.conf import settings
 from django.utils.cache import patch_vary_headers
-from django.utils.http import cookie_date
+from django.utils.http import http_date
 
 try:
     from importlib import import_module
@@ -49,7 +49,7 @@ class SessionMiddleware(MiddlewareMixin):
                 else:
                     max_age = request.session.get_expiry_age()
                     expires_time = time.time() + max_age
-                    expires = cookie_date(expires_time)
+                    expires = http_date(expires_time)
                 # Save the session data and refresh the client cookie.
                 # Skip session save for 500 responses, refs #3881.
                 if response.status_code != 500:


### PR DESCRIPTION
django.utils.http.cookie_date has been deprecated since Django 2.2. So changing to support newer Django versions.