### PR TITLE
Fix: Use http_date instead of cookie_date (deprecated since Django 2.2)

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -2,7 +2,11 @@ import time
 
 from django.conf import settings
 from django.utils.cache import patch_vary_headers
-from django.utils.http import cookie_date
+
+try:
+    from django.utils.http import cookie_date
+except ImportError:
+    from django.utils.http import http_date as cookie_date
 
 try:
     from importlib import import_module


### PR DESCRIPTION
cookie_date has been deprecated since Django 2.2. Adding a simple try block to use cookie_date as an alias of http_date.