### PR TITLE
Stop using GeoIP in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,3 @@ tx-pull:
 tx-push:
 	cd user_sessions; django-admin.py makemessages -l en
 	tx push -s
-
-download-geoip:
-	if [ ! -f GeoLite2-City.mmdb ]; then wget http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz; gunzip GeoLite2-City.mmdb.gz; fi

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,7 +8,7 @@ from django.contrib import auth
 from django.contrib.auth.models import User
 from django.contrib.sessions.backends.base import CreateError
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.test.utils import modify_settings, override_settings
 from django.urls import reverse
 from django.utils.timezone import now
@@ -447,7 +447,7 @@ class ClearsessionsCommandTest(TestCase):
         self.assertEqual(Session.objects.count(), 0)
 
 
-class MigratesessionsCommandTest(TestCase):
+class MigratesessionsCommandTest(TransactionTestCase):
     @modify_settings(INSTALLED_APPS={'append': 'django.contrib.sessions'})
     def test_migrate_from_login(self):
         from django.contrib.sessions.models import Session as DjangoSession

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ DJANGO =
 
 [testenv]
 commands = 
-    make download-geoip
     coverage run {envbindir}/django-admin.py test -v 2 --pythonpath=./ --settings=tests.settings
     coverage report
 deps =


### PR DESCRIPTION
Due to US privacy laws, GeoIP database is no longer freely available and requires an account. I don't like having to sign up and agree to some terms for the sake of getting the tests to pass. Let alone the work required to setup Travis CI to download the database with a private token.