### PR TITLE
Update build matrix to target current Django 2.2+ versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,22 @@
 language: python
+dist: xenial
 
 python:
- - 3.4
- - 3.5
  - 3.6
+ - 3.7
+ - 3.8
 
 env:
- - DJANGO=1.11
- - DJANGO=2.0
+ - DJANGO=2.2
+ - DJANGO=3.0
+ - DJANGO=master
 
 matrix:
   include:
-    - python: 2.7
-      env: DJANGO=1.11
+    - python: 3.5
+      env: DJANGO=2.2
 
-    - python: 3.5
-      env: DJANGO=master
-    - python: 3.6
-      env: DJANGO=master
-
-    - python: 3.5
-      env: TOXENV=isort
-    - python: 3.5
+    - python: 3.8
       env: TOXENV=flake8
 
   allow_failures:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,6 +14,17 @@ Installation
 7. Run ``python manage.py syncdb`` (or ``migrate``) and browse to
    ``/account/sessions/``.
 
+System check framework
+----------------------
+
+Django warns you about common configuration errors. When replacing the session
+middleware with the one provided by this library, it'll start warning about
+`admin.E410`. You can silence this warning by adding the following line in
+your settings file:
+
+    SILENCED_SYSTEM_CHECKS = ['admin.E410']
+
+
 GeoIP
 -----
 You need to setup GeoIP for the location detection to work. See the Django

--- a/example/settings.py
+++ b/example/settings.py
@@ -77,3 +77,5 @@ GEOIP_PATH = os.path.join(os.path.dirname(PROJECT_PATH), 'GeoLite2-City.mmdb')
 
 LOGIN_URL = '/admin/'
 LOGOUT_REDIRECT_URL = '/admin/'
+
+SILENCED_SYSTEM_CHECKS = ['admin.E410']

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -60,3 +60,5 @@ SESSION_ENGINE = 'user_sessions.backends.db'
 
 LOGIN_URL = '/admin/'
 LOGOUT_REDIRECT_URL = '/'
+
+SILENCED_SYSTEM_CHECKS = ['admin.E406', 'admin.E409', 'admin.E410']

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -26,10 +26,6 @@ try:
 except ImportError:
     from mock import patch
 
-
-
-
-
 try:
     from django.contrib.gis.geoip2 import GeoIP2
     geoip = GeoIP2()
@@ -168,6 +164,7 @@ class AdminTest(TestCase):
 class SessionStoreTest(TestCase):
     def setUp(self):
         self.store = SessionStore(user_agent='Python/2.7', ip='127.0.0.1')
+        User.objects.create_user('bouke', '', 'secret', id=1)
 
     def test_untouched_init(self):
         self.assertFalse(self.store.modified)
@@ -255,6 +252,7 @@ class SessionStoreTest(TestCase):
 
 class ModelTest(TestCase):
     def test_get_decoded(self):
+        User.objects.create_user('bouke', '', 'secret', id=1)
         store = SessionStore(user_agent='Python/2.7', ip='127.0.0.1')
         store[auth.SESSION_KEY] = 1
         store['foo'] = 'bar'

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 ; Minimum version of Tox
 minversion = 1.8
 envlist =
-    py{27,34,35,36}-{dj111},
-    py{34,35,36}-{dj20},
-    py{35,36}-{djmaster},
+    py{35,36,37,38}-{dj22},
+    py{36,37,38}-{dj30,djmaster},
     flake8
 
 [travis]
@@ -12,8 +11,8 @@ unignore_outcomes = True
 
 [travis:env]
 DJANGO =
-    1.11: dj111
-    2.0: dj20
+    2.2: dj22
+    3.0: dj30
     master: djmaster
 
 [testenv]
@@ -22,21 +21,14 @@ commands =
     coverage report
 deps =
     coverage
-    geoip2
-    py27: mock
-    dj111: Django<1.12
-    dj20: Django<2.1
+    dj22: Django<2.3
+    dj30: Django<3.1
     djmaster: https://github.com/django/django/archive/master.tar.gz
 ignore_outcome =
     djmaster: True
 whitelist_externals = make
 
 [testenv:flake8]
-basepython = python3.5
+basepython = python3.8
 deps = flake8
 commands = flake8 two_factor
-
-[testenv:isort]
-basepython = python3.5
-deps = isort
-commands = isort -rc -c --diff example tests two_factor

--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -2,7 +2,7 @@ import time
 
 from django.conf import settings
 from django.utils.cache import patch_vary_headers
-from django.utils.http import cookie_date
+from django.utils.http import http_date
 
 try:
     from importlib import import_module
@@ -49,7 +49,7 @@ class SessionMiddleware(MiddlewareMixin):
                 else:
                     max_age = request.session.get_expiry_age()
                     expires_time = time.time() + max_age
-                    expires = cookie_date(expires_time)
+                    expires = http_date(expires_time)
                 # Save the session data and refresh the client cookie.
                 # Skip session save for 500 responses, refs #3881.
                 if response.status_code != 500:


### PR DESCRIPTION
Django 1.11 will soon be unsupported. Django 2.0 and 2.1 already are. So update the build matrix for modern Django versions: 2.2 and 3.0.